### PR TITLE
adds tom_eso ESO Facility interface to ESO P2 Tool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "tom_alertstreams",
     "tom_fink",
     "tom-registration",
+    "tom_eso",
 ]
 
 [project.urls]

--- a/src/fomo/settings.py
+++ b/src/fomo/settings.py
@@ -62,6 +62,7 @@ INSTALLED_APPS = [
     'tom_alertstreams',
     'tom_fink',
     'tom_registration',
+    'tom_eso',
 ]
 
 SITE_ID = 1
@@ -251,6 +252,7 @@ TOM_FACILITY_CLASSES = [
     'tom_observations.facilities.lco.LCOFacility',
     'tom_observations.facilities.gemini.GEMFacility',
     'tom_observations.facilities.soar.SOARFacility',
+    'tom_eso.eso.ESOFacility',
 ]
 
 TOM_REGISTRATION = {


### PR DESCRIPTION
These are the changes to FOMO required to install the prototype TOMToolkit ESO Facility. (This facility is a prototype and we are interested in your feedback).

- `pyproject.toml` : add `tom_eso` as dependency
- `settings.py` : 
  - add `tom_eso` to `INSTALLED_APPS` list
  - add `tom_eso.eso.ESOFacility` to `TOM_FACILITY_CLASSES`

Don't merge this PR yet! Before you can install `tom_eso`, we need to:
- [ ] make a TOMToolkit PyPI release with a few changes needed for `tom_eso`
- [ ] release `tom_eso` to PyPI

If you want preview this before we the make `tomtoolkit` and `tom_eso` PyPI releases, let me know and I can set you up with local installations of the branches you'd need.