### PR TITLE
Make FOMO Targets OPEN by default. Add MPCHarvester now it has comet support. Update dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dynamic = ["version"]
 requires-python = ">=3.9"
 dependencies = [
-    "tomtoolkit>=2.23.1",
+    "tomtoolkit>=2.26.0",
     "tom_alertstreams",
     "tom_fink",
     "tom-registration",

--- a/src/fomo/settings.py
+++ b/src/fomo/settings.py
@@ -309,6 +309,7 @@ TOM_HARVESTER_CLASSES = [
     'tom_catalogs.harvesters.simbad.SimbadHarvester',
     'tom_catalogs.harvesters.jplhorizons.JPLHorizonsHarvester',
     'tom_catalogs.harvesters.tns.TNSHarvester',
+    'tom_catalogs.harvesters.mpc.MPCHarvester',
     'tom_catalogs.harvesters.mpc.MPCExplorerHarvester',
 ]
 
@@ -334,6 +335,11 @@ AUTH_STRATEGY = 'READ_ONLY'
 # objects to be seen by everyone. Setting it to False will allow users to specify which groups can access
 # `ObservationRecord`, `DataProduct`, and `ReducedDatum` objects.
 TARGET_PERMISSIONS_ONLY = True
+
+
+# Default permission for newly created targets. Values can be 'PRIVATE', 'PUBLIC', or 'OPEN'
+# Set FOMO default to 'OPEN' (visible to everyone, even when not logged in)
+TARGET_DEFAULT_PERMISSION = 'OPEN'
 
 # URLs that should be allowed access even with AUTH_STRATEGY = LOCKED
 # for example: OPEN_URLS = ['/', '/about']


### PR DESCRIPTION
## Change Description
Now  tomtoolkit 2.26.0 has been released the following PRs on `tom_base`:

- [#1255 (Add extra MPCHarvester functionality)](https://github.com/TOMToolkit/tom_base/pull/1255)
- [#1270 (Default Target permissions)](https://github.com/TOMToolkit/tom_base/pull/1270)
have been merged allowing FOMO to use them. 
This PR adds these and uprevs the dependency on tomtoolkit.



## Solution Description
In `src/fomo/settings.py`:
- Set `TARGET_DEFAULT_PERMISSION = 'OPEN'`and added explanation of what this means
- Add `tom_catalogs.harvesters.mpc.MPCHarvester` into `TOM_HARVESTER_CLASSES

Changed minimum version of `tomtoolkit` in `pyproject.toml` from `>=2.23.1` to `>=2.26.0`


## Code Quality
- [X] I have read the Contribution Guide
- [X] My code follows the code style of this project
- [X] My code builds (or compiles) cleanly without any errors or warnings
- [X] My code contains relevant comments and necessary documentation

