### PR TITLE
Uprev tomtoolkit dependency to 2.26.2 to get the H, G Target fields

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dynamic = ["version"]
 requires-python = ">=3.9"
 dependencies = [
-    "tomtoolkit>=2.26.0",
+    "tomtoolkit>=2.26.2",
     "tom_alertstreams",
     "tom_fink",
     "tom-registration",


### PR DESCRIPTION
## Change Description
This PR uprevs the dependency on tom_toolkit to 2.26.2 which include the addition of the _H,G_/`abs_mag,slope` parameters on `Target`. Closes #16 
- [x] My PR includes a link to the issue that I am addressing



## Solution Description
The additional fields on `Target` and the associated migrations were added into tom_base in [tom_base Issue #1282](https://github.com/TOMToolkit/tom_base/issues/1282) and [tom_base PR #1293](https://github.com/TOMToolkit/tom_base/pull/1293)
This replaces the `Target.extra_fields` but this is only in use in one place on the `feature/add_ephem_gen` so won't be hard to update.


## Code Quality
N/A

## Project-Specific Pull Request Checklists

### Other Change Checklist
- [ ] Any new or updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
- [ ] I have added unit/End-to-End (E2E) test cases to cover any changes
- [X] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)
