### PR TITLE
tom-toolkit 3.0 migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,7 @@ dmypy.json
 # vscode
 .vscode/
 .vs/
+**/*.code-workspace
 
 # dask
 dask-worker-space/

--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ db.sqlite3
 db.sqlite3-journal
 fomo_db.sqlite3
 fomo_db.sqlite3-journal
+rubin.sqlite
 
 # Flask stuff:
 instance/
@@ -156,5 +157,4 @@ _html/
 # Serena MCP
 .serena/
 
-# Local SQLite databases
-rubin.sqlite
+docs/notebooks/data/**

--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,9 @@ _html/
 
 # Project initialization script
 .initialize_new_project.sh
+
+# Serena MCP
+.serena/
+
+# Local SQLite databases
+rubin.sqlite

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,95 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+FOMO (Follow-up Observations of Moving Objects) is a Django web app built on the
+[TOM Toolkit](https://tom-toolkit.readthedocs.io/) for coordinating follow-up observations of
+interesting Solar System targets, primarily from the Vera C. Rubin Observatory. It computes
+ephemerides for non-sidereal targets and ingests minor-body orbits from JPL.
+
+## Commands
+
+```bash
+# One-time dev setup (editable install + dev deps + pre-commit). Use a fresh conda/venv first.
+./.setup_dev.sh
+
+# Run the Django dev server / any admin task. Settings module is src.fomo.settings (set by manage.py).
+./manage.py runserver
+./manage.py migrate
+./manage.py createsuperuser
+
+# Custom management command: query JPL SBDB and create Targets from new matches
+./manage.py fetch_jplsbdb_objects --orbital_constraints "e>=1.2,q<1.3" --group_name NEOs
+./manage.py fetch_jplsbdb_objects --orbit_class IEO
+
+# Tests — there are TWO independent test suites (see "Testing" below):
+python -m pytest                          # pytest suite: tests/, src/, docs/ only
+./manage.py test                          # Django app tests (solsys_code et al.)
+./manage.py test solsys_code.tests.test_views.TestSplitNumberUnitRegex   # single Django test
+
+# Lint / format (also enforced by pre-commit). Single quotes, 120-col line length.
+ruff check . --fix
+ruff format .
+```
+
+## Layout (non-obvious)
+
+- `src/fomo/` is **only** the Django project config (`settings.py`, `urls.py`, `wsgi.py`). There is no
+  app code here. `manage.py` sets `DJANGO_SETTINGS_MODULE=src.fomo.settings`, but `settings.py` itself
+  refers to `fomo.urls` / `fomo.wsgi`, so `src/` must be importable as a path root.
+- `solsys_code/` (at the repo **root**, not under `src/`) is the main custom Django app and holds nearly
+  all the real logic. `solsys_code/solsys_code_observatory/` is a nested sub-app for MPC observatories.
+- `src/templates/` and `src/templatetags/` hold the project-level templates and template tags
+  (the `solsys_code_extras` / `fomo_extras` tag libraries, registered via `INSTALLED_APPS`).
+
+## Architecture
+
+Two largely separate feature areas, both living in `solsys_code/`:
+
+**1. Ephemeris generation** (`solsys_code/views.py` `Ephemeris`/`MakeEphemerisView`, backed by
+`solsys_code/ephem_utils.py`). A `Target`'s orbital elements are converted to a barycentric cartesian
+state vector (`convert_target_to_layup`), integrated forward with **REBOUND + ASSIST** under full GR
+(`generate_assist_simulations`), and turned into RA/Dec/rates via **sorcha** light-time integration.
+Positions are then transformed to observed Alt/Az/HA with **erfa/SOFA** (`build_apco_context`,
+`calculate_rates_and_geometry`), and apparent magnitude + sky motion are appended
+(`add_magnitude`, `add_sky_motion`). Output is rendered as an ephemeris table.
+
+> **Heavy import side effect:** importing `solsys_code.ephem_utils` (transitively, `solsys_code.views`)
+> runs `fomo_furnish_spiceypy()` at module load, which downloads **~1.6 GB of SPICE kernels** to
+> `~/.cache/sorcha/` on first use and builds the ASSIST ephemeris. Anything that imports these modules
+> (including `manage.py test` collecting `solsys_code/tests/`) pays this cost.
+
+**2. Target ingestion from JPL** (`solsys_code/views.py` `JPLSBDBQuery`, exposed via the
+`fetch_jplsbdb_objects` management command). Builds Small-Body Database Query API URLs from
+human-readable constraint strings (e.g. `"e>=1.2"`, `"1.0<a<2.0"`, `"H is defined"`; translated to the
+API's `field|OP|value` form in `_translate_constraints`), parses results into an astropy `QTable`, and
+creates `tom_targets.Target` rows (asteroids vs. comets handled differently for naming and H/G vs M1/K1).
+
+**Observatories** (`solsys_code/solsys_code_observatory/`): the `Observatory` model stores MPC site
+codes and geodetic position, with conversions between MPC parallax constants and lat/lon/alt (erfa).
+`utils.MPCObscodeFetcher` populates it from the MPC Observatory Codes API.
+
+**TOM plugins & data services** are wired in `settings.py` (`INSTALLED_APPS`, `TOM_FACILITY_CLASSES`,
+`TOM_ALERT_CLASSES`, `ALERT_STREAMS`, `DATA_SERVICES`). Notably JPL Scout and Fink are registered as
+data services via `SolsysCodeConfig.data_services()` in `solsys_code/apps.py`; the navbar and
+target-detail buttons are injected via the app-config integration hooks (`nav_items`,
+`target_detail_buttons`).
+
+## Testing
+
+`pyproject.toml` sets `testpaths = ["tests", "src", "docs"]`, so **`python -m pytest` does NOT collect
+the Django app tests** under `solsys_code/`. Those use `django.test.TestCase` and run under the Django
+test runner (`./manage.py test`). When adding tests, put pure-Python/packaging tests under `tests/` and
+Django/DB-dependent tests under the relevant app's `tests/` package.
+
+## Conventions
+
+- Database is local SQLite (`src/fomo_db.sqlite3`); `DEBUG=True` and the secret key in `settings.py` are
+  dev defaults — production overrides belong in a `local_settings.py` (imported at the end of `settings.py`).
+- Targets are `NON_SIDEREAL`; default target permission is `OPEN` and `AUTH_STRATEGY='READ_ONLY'`.
+- ruff config (`pyproject.toml`) follows Rubin DM style: many `N8xx` naming rules are intentionally
+  ignored so astronomical variable names (e.g. `H`, `G`, `RA_deg`) are allowed. Format with single quotes.
+- pre-commit blocks direct commits to `main`, clears Jupyter notebook output, runs ruff, builds Sphinx
+  docs, and runs the pytest suite. CI (`.github/workflows/`) tests Python 3.10–3.12.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,11 +17,11 @@ classifiers = [
 dynamic = ["version"]
 requires-python = ">=3.10"
 dependencies = [
-    "tomtoolkit>=2.31.4",
-    "tom_alertstreams",
+    "tomtoolkit>=3.0.0a9",  # pre-release specifier opts into the 3.0 alpha required by tom_jpl/tom_fink
+    "tom_alertstreams>=1.2.1",
     "tom_fink>=1.0.0",
-    "tom-registration",
-    "tom_eso>=0.2.2",
+    "tom-registration>=1.0.5",
+    "tom_eso>=0.2.4",
     "numpy>1.24",
     "sbpy>=0.6.0",  # We don't use sbpy directly, but sorcha does and sbpy 0.6.0 is needed for astropy 7.2.0+
     "sorcha",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "tom-registration",
     "tom_eso",
     "numpy>1.24",
+    "sbpy>=0.6.0",  # We don't use sbpy directly, but sorcha does and sbpy 0.6.0 is needed for astropy 7.2.0+
     "sorcha",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "tom_alertstreams",
     "tom_fink>=1.0.0",
     "tom-registration",
-    "tom_eso",
+    "tom_eso>=0.2.2",
     "numpy>1.24",
     "sbpy>=0.6.0",  # We don't use sbpy directly, but sorcha does and sbpy 0.6.0 is needed for astropy 7.2.0+
     "sorcha",

--- a/solsys_code/solsys_code_observatory/utils.py
+++ b/solsys_code/solsys_code_observatory/utils.py
@@ -2,7 +2,7 @@ import logging
 from datetime import datetime, timezone
 
 import requests
-from tom_catalogs.harvester import MissingDataException
+from tom_dataservices.dataservices import MissingDataException
 
 from solsys_code.solsys_code_observatory.models import Observatory
 

--- a/solsys_code/solsys_code_observatory/views.py
+++ b/solsys_code/solsys_code_observatory/views.py
@@ -7,7 +7,7 @@ from django.http import HttpResponse
 from django.shortcuts import redirect
 from django.urls import reverse_lazy
 from django.views.generic import CreateView, DetailView, ListView
-from tom_catalogs.harvester import MissingDataException
+from tom_dataservices.dataservices import MissingDataException
 
 from solsys_code.solsys_code_observatory.forms import CreateObservatoryForm
 from solsys_code.solsys_code_observatory.models import Observatory

--- a/solsys_code/tests/test_views.py
+++ b/solsys_code/tests/test_views.py
@@ -120,10 +120,8 @@ class TestEphemeris(TestCase):
         self.assertInHTML(expected_result, response.content.decode())
 
     def test_no_site(self):
-        expected_result = 'Not Found'
-
         response = self.client.get(reverse('ephem', kwargs={'pk': self.test_target.pk}) + '?obscode=500')
-        self.assertInHTML(expected_result, response.content.decode())
+        self.assertEqual(response.status_code, 404)
 
 
 class TestJPLSBDBQuery(TestCase):

--- a/src/fomo/settings.py
+++ b/src/fomo/settings.py
@@ -42,6 +42,8 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'django.contrib.sites',
     'django_extensions',
+    'django_tasks',
+    'django_tasks.backends.database',
     'guardian',
     'tom_common',
     'django_comments',
@@ -56,16 +58,16 @@ INSTALLED_APPS = [
     'django_htmx',
     'tom_targets',
     'tom_alerts',
-    'tom_catalogs',
     'tom_observations',
     'tom_dataproducts',
+    'tom_dataservices',
+    'tom_calendar',
     'solsys_code',
     'solsys_code.solsys_code_observatory.apps.SolsysCodeObservatoryConfig',
     'tom_alertstreams',
     'tom_fink',
     'tom_registration',
     'tom_eso',
-    'tom_dataservices',
 ]
 
 SITE_ID = 1
@@ -309,15 +311,9 @@ BROKERS = {
     },
 }
 
-TOM_HARVESTER_CLASSES = [
-    'tom_catalogs.harvesters.jplhorizons.JPLHorizonsHarvester',
-    'tom_catalogs.harvesters.mpc.MPCHarvester',
-    'tom_catalogs.harvesters.mpc.MPCExplorerHarvester',
-    'tom_catalogs.harvesters.simbad.SimbadHarvester',
-    'tom_catalogs.harvesters.tns.TNSHarvester',
-]
-
-HARVESTERS = {'TNS': {'api_key': ''}}
+# Per-service configuration for tom_dataservices DataServices (catalog services such as
+# MPC Explorer, Simbad, TNS, ... are auto-registered in tomtoolkit 3.0)
+DATA_SERVICES = {}
 
 # Define extra target fields here. Types can be any of "number", "string", "boolean" or "datetime"
 # See https://tomtoolkit.github.io/docs/target_fields for documentation on this feature


### PR DESCRIPTION


## Change Description
Updates the dependencies to those compatible with the 3.0alpha9 version of the `tom_toolkit` Also fixes #31 as MPC Explorer DataService comes along for free
- [x] My PR includes a link to the issue that I am addressing



## Solution Description
Patches cherry-picked off the `issue29-jpl-scout-ingest` with Claude's assistance for the original dependency update resolution



## Code Quality
- [x] I have read the Contribution Guide
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation

## Project-Specific Pull Request Checklists
<!--- Please only use the checklist that apply to your change type(s) -->


### Build/CI Change Checklist
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the README to reflect this
- [ ] If this is a new CI setup, I have added the associated badge to the README

